### PR TITLE
Fix 2 annoying crashes

### DIFF
--- a/src/sdl/mixer_sound.c
+++ b/src/sdl/mixer_sound.c
@@ -90,6 +90,7 @@ static UINT32 fading_timer;
 static UINT32 fading_duration;
 static INT32 fading_id;
 static void (*fading_callback)(void);
+static boolean fading_do_callback;
 
 #ifdef HAVE_LIBGME
 static Music_Emu *gme;
@@ -106,6 +107,7 @@ static void var_cleanup(void)
 	 is_fading = false;
 
 	fading_callback = NULL;
+	fading_do_callback = false;
 
 	internal_volume = 100;
 }
@@ -202,6 +204,13 @@ void I_ShutdownSound(void)
 
 void I_UpdateSound(void)
 {
+	if (fading_do_callback)
+	{
+		if (fading_callback)
+			(*fading_callback)();
+		fading_callback = NULL;
+		fading_do_callback = false;
+	}
 }
 
 /// ------------------------
@@ -526,9 +535,8 @@ static UINT32 get_adjusted_position(UINT32 position)
 
 static void do_fading_callback(void)
 {
-	if (fading_callback)
-		(*fading_callback)();
-	fading_callback = NULL;
+	// TODO: Should I use a mutex here or something?
+	fading_do_callback = true;
 }
 
 /// ------------------------


### PR DESCRIPTION
Fixes FreeMipmapColormap crash that often happens in longer playsessions on servers with many different maps
also fixes some music changes which are set to fade the music volume that sometimes crash the game
Both are Backports from SRB2 and have recently been also merged into Galaxy fork
Credits for those go to Lactozilla from Sonic Team Jr.

I also include a map which i made specifically for testing the Music fade crash
[fadetest3.zip](https://github.com/STJr/Kart-Public/files/12340471/fadetest3.zip)
