### PR TITLE
Fix segmentation faults on 32-bit ARM devices running GNU/Linux

### DIFF
--- a/src/z_zone.c
+++ b/src/z_zone.c
@@ -242,7 +242,7 @@ void *Z_Malloc2(size_t size, INT32 tag, void *user, INT32 alignbits,
 void *Z_MallocAlign(size_t size, INT32 tag, void *user, INT32 alignbits)
 #endif
 {
-	size_t extrabytes = (1<<alignbits) - 1;
+	size_t extrabytes = (1<<alignbits) - (sizeof(size_t)*8 > (UINT32) alignbits); // only subtract 1 if the bit shift did not cause an overflow
 	size_t padsize = 0;
 	memblock_t *block;
 	void *ptr;


### PR DESCRIPTION
I tried to run SRB2Kart on my ODROID-XU4, which is a 32-bit ARMv7h device, and I would consistently get segmentation faults when Z_MallocAlign() was called with an alignbits value greater than or equal to 32. I found that the 1<<alignbits call would overflow and evaluate to 0. This would then have 1 subtracted from it, causing an underflow and setting extrabytes equal to 0xFFFFFFFF. This excessively high value for extrabytes causes weird memory corruption errors that eventually lead to a segmentation fault.

I have corrected this issue by not subtracting 1 when an overflow is guaranteed to have occurred.

Weirdly enough, this problem does not occur on 64-bit Intel, even though an alignbits value of 64 would still cause an overflow. extrabytes is still set to 0 even when alignbits is 64. This probably has to do with differences in the CPU overflow flag when bit shifting too much to the left.

Another interesting thing is that https://github.com/STJr/SRB2 apparently had some memory management updates (https://github.com/STJr/SRB2/commit/cee5eb47b591b2b0a333198243e632607fb9585f) that removed the left bit shift operation entirely, but these updates have not made their way into SRB2Kart yet.